### PR TITLE
Add helmfile-workdirectory input to action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
     required: false
     description: 'Helm version'
     default: 'latest'
+  helmfile-workdirectory:
+    required: false
+    description: 'Helmfile working directory'
+    default: '.'
   helm-plugins:
     required: false
     description: 'Comma separated list of Helm plugins to install'


### PR DESCRIPTION
The input is added to the action yaml. To avoid the warning:

![image](https://github.com/helmfile/helmfile-action/assets/5618170/44b64895-5ab7-4314-86f2-50e279c72af5)
