### PR TITLE
docs: Fix example version of helmfile-action in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action works on Linux, macOS and Windows
 Example with optional inputs
 
 ```yaml
-- uses: helmfile/helmfile-action@v2.0.4
+- uses: helmfile/helmfile-action@v2.0.5
   with:
     helmfile-version: 'v0.150.0'
     helm-version: 'v3.11.0'


### PR DESCRIPTION
I found that helm-plugins version pinning is updated at version v2.0.5 but example was v2.0.4.

related to
https://github.com/helmfile/helmfile-action/pull/542