### PR TITLE
build(deps-dev): bump brace-expansion to 5.0.9 and js-yaml to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,9 +3041,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4745,9 +4745,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "overrides": {
     "@typescript-eslint/utils": "^8.65.0",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "glob": "^11.0.1",
     "test-exclude": "^8.0.0"
   },


### PR DESCRIPTION
## Description

Update transitive dev dependencies to their latest patch releases.

- `brace-expansion`: `5.0.8` -> `5.0.9` (also bumped the `overrides` entry in `package.json` from `^5.0.8` to `^5.0.9`)
- `js-yaml`: `3.15.0` -> `3.15.1` (transitive — only reflected in the lockfile)

## Type of change

- [x] Chore / dependency update (patch-level, no API changes)

## Checklist

- [x] `package-lock.json` updated
- [x] `package.json` override bumped to match the resolved version